### PR TITLE
Providing token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 build
+.token

--- a/node-client/examples/connect.ts
+++ b/node-client/examples/connect.ts
@@ -27,9 +27,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.getInformation,
       reference: '1',

--- a/node-client/examples/connect.ts
+++ b/node-client/examples/connect.ts
@@ -55,5 +55,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/examples/subscribeToAlarms.ts
+++ b/node-client/examples/subscribeToAlarms.ts
@@ -56,5 +56,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/examples/subscribeToAlarms.ts
+++ b/node-client/examples/subscribeToAlarms.ts
@@ -28,9 +28,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.subscribe,
       payload: [SubscriptionChannel.alarms],

--- a/node-client/examples/subscribeToAll.ts
+++ b/node-client/examples/subscribeToAll.ts
@@ -28,9 +28,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.subscribe,
       payload: Object.values(SubscriptionChannel),

--- a/node-client/examples/subscribeToAll.ts
+++ b/node-client/examples/subscribeToAll.ts
@@ -64,5 +64,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/examples/subscribeToMonitorings.ts
+++ b/node-client/examples/subscribeToMonitorings.ts
@@ -56,5 +56,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/examples/subscribeToMonitorings.ts
+++ b/node-client/examples/subscribeToMonitorings.ts
@@ -28,9 +28,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.subscribe,
       payload: [SubscriptionChannel.monitorings],

--- a/node-client/examples/subscribeToSettings.ts
+++ b/node-client/examples/subscribeToSettings.ts
@@ -56,5 +56,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/examples/subscribeToSettings.ts
+++ b/node-client/examples/subscribeToSettings.ts
@@ -28,9 +28,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.subscribe,
       payload: [SubscriptionChannel.settings],

--- a/node-client/examples/subscribeToVentilation.ts
+++ b/node-client/examples/subscribeToVentilation.ts
@@ -56,5 +56,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/examples/subscribeToVentilation.ts
+++ b/node-client/examples/subscribeToVentilation.ts
@@ -28,9 +28,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.subscribe,
       payload: [SubscriptionChannel.ventilation],

--- a/node-client/examples/subscribeToWaveforms.ts
+++ b/node-client/examples/subscribeToWaveforms.ts
@@ -28,9 +28,7 @@ async function main(): Promise<void> {
 
   async function onConnected() {
     logger.info('Connected');
-    await client.writeMessage({
-      type: ClientMessageType.startCommunication,
-    });
+    await client.startCommunication();
     await client.writeMessage({
       type: ClientMessageType.subscribe,
       payload: [SubscriptionChannel.waveforms],

--- a/node-client/examples/subscribeToWaveforms.ts
+++ b/node-client/examples/subscribeToWaveforms.ts
@@ -56,5 +56,6 @@ async function main(): Promise<void> {
     await wait(1000);
     await client.disconnect();
     client.dispose();
+    process.exit();
   }
 }

--- a/node-client/lib/hisClient.ts
+++ b/node-client/lib/hisClient.ts
@@ -205,6 +205,7 @@ export class HisClient extends EventEmitter {
   }
 
   private readTokenIfAny(): Promise<string | undefined> {
+    this.logger.debug(`Reading token from ${this.tokenFile}`);
     return readFile(this.tokenFile, { encoding: 'utf-8' }).catch((error) => {
       if (error.code !== 'ENOENT') {
         this.logger.error('Unexpected error while reading token', error);

--- a/node-client/lib/index.ts
+++ b/node-client/lib/index.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { HisClient, HisClientCreation } from './hisClient';
 import { createConsoleLogger } from './tools';
 import {
@@ -22,6 +24,7 @@ interface Creation extends Partial<HisClientCreation> {
   accessoryManufacturer?: string;
   accessoryModel?: string;
   readBufferLength?: number;
+  tokenFile?: string;
 }
 
 export function createHisClient(creation: Creation = {}): HisClient {
@@ -39,6 +42,7 @@ export function createHisClient(creation: Creation = {}): HisClient {
     inTimeoutMs = 1000,
     outTimeoutMs = 5000,
     readBufferLength = 10000,
+    tokenFile,
   } = creation;
   const logger = createConsoleLogger({ debugEnabled });
   const findUsbDevice = createFindUsbDevice({ logger });
@@ -63,6 +67,7 @@ export function createHisClient(creation: Creation = {}): HisClient {
     accessoryModel,
     logger,
   });
+  const safeTokenFile = getTokenFile(tokenFile, serialNumber);
   return new HisClient(
     Object.assign(
       {
@@ -73,10 +78,22 @@ export function createHisClient(creation: Creation = {}): HisClient {
         messageLineParser,
         inTimeoutMs,
         outTimeoutMs,
+        tokenFile: safeTokenFile,
       },
       creation
     )
   );
+}
+
+function getTokenFile(
+  fileMaybe: string | undefined,
+  serialNumberMaybe: string | undefined
+): string {
+  if (fileMaybe) {
+    return fileMaybe;
+  }
+  const suffix = serialNumberMaybe ? `-${serialNumberMaybe}` : '';
+  return path.join(process.cwd(), `.token${suffix}`);
 }
 
 export * from './message';

--- a/node-client/lib/message/message.ts
+++ b/node-client/lib/message/message.ts
@@ -15,6 +15,7 @@ export enum ClientMessageType {
 
 export enum ServerMessageType {
   ping = 'PING',
+  startCommunicationSucceeded = 'START_COMMUNICATION_SUCCEEDED',
 }
 
 export function serializeMessage(message: Message): Buffer {

--- a/node-client/lib/tests/index.ts
+++ b/node-client/lib/tests/index.ts
@@ -1,2 +1,3 @@
+export * from './log';
 export * from './mock';
 export * from './samples';

--- a/node-client/lib/tests/log.ts
+++ b/node-client/lib/tests/log.ts
@@ -1,0 +1,9 @@
+import { Logger } from '../tools';
+
+export function createSilentLogger(): Logger {
+  return {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}

--- a/node-client/lib/tools/log.ts
+++ b/node-client/lib/tools/log.ts
@@ -20,11 +20,3 @@ export function createConsoleLogger(
     debug: debugEnabled ? console.debug.bind(console) : () => undefined,
   };
 }
-
-export function createSilentLogger(): Logger {
-  return {
-    info: () => undefined,
-    error: () => undefined,
-    debug: () => undefined,
-  };
-}

--- a/node-client/lib/usb/accessoryModeConfigurator.spec.ts
+++ b/node-client/lib/usb/accessoryModeConfigurator.spec.ts
@@ -4,8 +4,7 @@ import {
   AccessoryModeConfigurator,
   AccessoryModeConfiguratorCreation,
 } from './accessoryModeConfigurator';
-import { samples } from '../tests';
-import { createSilentLogger } from '../tools';
+import { samples, createSilentLogger } from '../tests';
 import { UsbDevice } from './usbDevice';
 
 describe('Accessory mode configurator', () => {

--- a/node-client/lib/usb/deviceFinder.spec.ts
+++ b/node-client/lib/usb/deviceFinder.spec.ts
@@ -1,8 +1,7 @@
 import { isEqual } from 'lodash/fp';
 
 import { DeviceFinder, DeviceFinderCreation } from './deviceFinder';
-import { samples } from '../tests';
-import { createSilentLogger } from '../tools';
+import { samples, createSilentLogger } from '../tests';
 import { FindUsbDevice, FindUsbDevices } from './usbDevice';
 
 describe('Device finder', () => {

--- a/node-client/lib/usb/usbReader.spec.ts
+++ b/node-client/lib/usb/usbReader.spec.ts
@@ -1,5 +1,5 @@
-import { mock } from '../tests';
-import { createSilentLogger, wait } from '../tools';
+import { mock, createSilentLogger } from '../tests';
+import { wait } from '../tools';
 import { UsbDevice } from './usbDevice';
 import { UsbReader, UsbReaderCreation, UsbReaderEvent } from './usbReader';
 

--- a/node-client/package-lock.json
+++ b/node-client/package-lock.json
@@ -920,15 +920,15 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.180",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
-      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.22.tgz",
-      "integrity": "sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==",
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
+      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1777,9 +1777,9 @@
       }
     },
     "eslint": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-      "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.1",
@@ -1817,14 +1817,6 @@
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        }
       }
     },
     "eslint-scope": {
@@ -1869,14 +1861,6 @@
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -3340,9 +3324,9 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -3707,9 +3691,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
     },
     "pretty-format": {
@@ -4185,9 +4169,9 @@
       }
     },
     "ts-jest": {
-      "version": "27.1.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
-      "integrity": "sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==",
+      "version": "27.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.4.tgz",
+      "integrity": "sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -4201,9 +4185,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4286,9 +4270,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "unbox-primitive": {
@@ -4319,9 +4303,9 @@
       }
     },
     "usb": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.1.3.tgz",
-      "integrity": "sha512-h5Hy7lQfrjJSrUKdLf+tNlEJb/moHXlsy5BIfQfL7XohJYr5UY2XYxebB3beIhG/xIlQW6cRwSayiIKXe21lWw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.3.1.tgz",
+      "integrity": "sha512-UdlcYC5rFhjFi2/NFfCz1HPoo5bQnDiB9916pg61gMyapoPgSNicGHdpQwia2UeVilDW/LZhUMiwOv5sYOkI9Q==",
       "requires": {
         "@types/w3c-web-usb": "1.0.6",
         "node-addon-api": "^4.2.0",

--- a/node-client/package.json
+++ b/node-client/package.json
@@ -32,22 +32,22 @@
     "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
-    "usb": "2.1.3"
+    "usb": "2.3.1"
   },
   "devDependencies": {
     "@eove/eslint-config-typescript": "1.7.0",
     "@types/jest": "27.4.1",
-    "@types/lodash": "4.14.180",
-    "@types/node": "17.0.22",
-    "eslint": "8.11.0",
+    "@types/lodash": "4.14.182",
+    "@types/node": "17.0.25",
+    "eslint": "8.13.0",
     "jest": "27.5.1",
     "lodash": "4.17.21",
     "npm-run-all": "4.1.5",
-    "prettier": "2.6.0",
+    "prettier": "2.6.2",
     "rimraf": "3.0.2",
-    "ts-jest": "27.1.3",
+    "ts-jest": "27.1.4",
     "ts-node": "10.7.0",
-    "typescript": "4.6.2"
+    "typescript": "4.6.3"
   },
   "jest": {
     "preset": "ts-jest"


### PR DESCRIPTION
When HIS connectivity is toggled on via EOVE-150 user interface, server will generate a **new and unique** communication token.
This token will not be required before a configured delay (typically 5 min).
During such delay client can connect, start high level communication and read the token in a response message.
Client should store this token (in a persistent storage) to be able to connect to the server later.
When the delay is expired the server will require the token for subsequent connections.
Note that client stays connected when server starts requiring token, there is no need to reconnect yet.

Example of communication start from client:

```json
{
  "type": "START_COMMUNICATION",
  "payload": {
    "token": "eoh_6af83e7c494e47d29c3ddc80ac0df354"
  }
}
```

Example of succeeded response from server when token is not required yet:

```json
{
  "type": "START_COMMUNICATION_SUCCEEDED",
  "payload": {
    "apiVersion": "1.0.0",
    "token": "eoh_6af83e7c494e47d29c3ddc80ac0df354"
  }
}
```

Example of error message client might receive:

```json
{
  "type": "START_COMMUNICATION_FAILED",
  "payload": {
    "reason": "missingToken"
  }
}
```